### PR TITLE
feat: IPv6 対応実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,18 +8,19 @@
 ## 構成
 
 ```
-[外部ブラウザ]
+[外部ブラウザ] (IPv4 / IPv6)
       ↓ TCP :XXXX
 [VPS (nginx + PHP-FPM)]
-      ↓ WireGuard トンネル (UDP :51821)
-[社内 PC (WireGuard for Windows)]
+      ↓ WireGuard トンネル (UDP :51821, IPv4 + IPv6)
+[社内 PC (WireGuard for Windows/Linux/macOS)]
       ↓ localhost
 [Web サーバー (XAMPP 等) :80]
 ```
 
 - VPS 上の nginx が PHP-FPM で本ポータルを提供
 - 利用者がポート番号を入力 → WireGuard 設定ファイルを生成・自動適用
-- iptables DNAT で外部ポートを WireGuard トンネル内の PC ポート 80 に転送
+- iptables/ip6tables DNAT で外部ポートを WireGuard トンネル内の PC ポート 80 に転送
+- IPv4・IPv6 の両方のトラフィックに対応
 
 ---
 
@@ -31,7 +32,9 @@
 | PHP | 8.1 以上 (php-fpm, php-sqlite3, php-sodium) |
 | Web サーバー | nginx |
 | WireGuard | `wireguard-tools` パッケージ |
-| 権限 | www-data が sudo で wg/iptables を実行できること |
+| iptables/ip6tables | `iptables` パッケージ |
+| IPv6 | Linux カーネルの IPv6 フォワーディング + ip6table_nat モジュール（オプション） |
+| 権限 | www-data が sudo で wg/iptables/ip6tables を実行できること |
 
 ---
 
@@ -41,7 +44,7 @@
 
 ```bash
 sudo apt update
-sudo apt install nginx php8.1-fpm php8.1-sqlite3 php8.1-sodium wireguard-tools -y
+sudo apt install nginx php8.1-fpm php8.1-sqlite3 php8.1-sodium wireguard-tools iptables -y
 ```
 
 ### 2. ファイルの配置
@@ -102,10 +105,22 @@ www-data ALL=(ALL) NOPASSWD: /usr/bin/tee /etc/wireguard/*
 www-data ALL=(ALL) NOPASSWD: /bin/chmod 600 /etc/wireguard/*
 www-data ALL=(ALL) NOPASSWD: /sbin/iptables -t nat -S PREROUTING
 www-data ALL=(ALL) NOPASSWD: /sbin/iptables -t nat -D PREROUTING *
+www-data ALL=(ALL) NOPASSWD: /sbin/iptables -t nat -A PREROUTING *
 www-data ALL=(ALL) NOPASSWD: /sbin/iptables -S FORWARD
 www-data ALL=(ALL) NOPASSWD: /sbin/iptables -D FORWARD *
+www-data ALL=(ALL) NOPASSWD: /sbin/iptables -A FORWARD *
 www-data ALL=(ALL) NOPASSWD: /sbin/iptables -t nat -S POSTROUTING
 www-data ALL=(ALL) NOPASSWD: /sbin/iptables -t nat -D POSTROUTING *
+www-data ALL=(ALL) NOPASSWD: /sbin/iptables -t nat -A POSTROUTING *
+www-data ALL=(ALL) NOPASSWD: /sbin/ip6tables -t nat -S PREROUTING
+www-data ALL=(ALL) NOPASSWD: /sbin/ip6tables -t nat -D PREROUTING *
+www-data ALL=(ALL) NOPASSWD: /sbin/ip6tables -t nat -A PREROUTING *
+www-data ALL=(ALL) NOPASSWD: /sbin/ip6tables -S FORWARD
+www-data ALL=(ALL) NOPASSWD: /sbin/ip6tables -D FORWARD *
+www-data ALL=(ALL) NOPASSWD: /sbin/ip6tables -A FORWARD *
+www-data ALL=(ALL) NOPASSWD: /sbin/ip6tables -t nat -S POSTROUTING
+www-data ALL=(ALL) NOPASSWD: /sbin/ip6tables -t nat -D POSTROUTING *
+www-data ALL=(ALL) NOPASSWD: /sbin/ip6tables -t nat -A POSTROUTING *
 ```
 
 ```bash
@@ -113,12 +128,22 @@ sudo chmod 440 /etc/sudoers.d/wireguard-portal
 sudo visudo -c  # 構文チェック
 ```
 
-### 6. IP フォワーディングの有効化
+### 6. IP フォワーディングの有効化（IPv4 & IPv6）
 
 ```bash
 echo "net.ipv4.ip_forward=1" | sudo tee -a /etc/sysctl.conf
+echo "net.ipv6.conf.all.forwarding=1" | sudo tee -a /etc/sysctl.conf
 sudo sysctl -p
 ```
+
+### 6.5. ip6table_nat モジュールの有効化（IPv6 NAT が必要な場合）
+
+```bash
+sudo modprobe ip6table_nat
+echo "ip6table_nat" | sudo tee -a /etc/modules
+```
+
+> **注：** 既存の WireGuard 設定を IPv6 対応にする場合は、管理画面の「IPv6 対応で全ポートを再適用」ボタンを押す前に、このモジュールのロードを完了してください。
 
 ### 7. ファイアウォールの開放
 
@@ -138,7 +163,8 @@ sudo ufw allow 51821/udp    # WireGuard (wg_port に合わせて変更)
 | VPS グローバル IP | クライアントが接続する VPS の IP またはドメイン |
 | WireGuard ポート (UDP) | VPS の WireGuard 待ち受けポート（デフォルト: `51820`） |
 | 外向き NIC 名 | VPS のネットワークインターフェース名（`ip a` で確認。例: `ens3`, `eth0`） |
-| WireGuard サブネット | VPN 内部ネットワーク（例: `10.100.10`） |
+| WireGuard サブネット | VPN 内部ネットワーク（例: `10.100.10`。先頭3オクテット） |
+| WireGuard IPv6 サブネット | VPN 内部の IPv6 ネットワーク（例: `fd00::`。ULA推奨） |
 | WireGuard インターフェース名 | `wg0` が使用中なら `wg1` や `wg10` など別名を指定 |
 | 設定生成時に自動適用 | 有効にすると生成時に自動で `wg-quick` を適用する |
 | ユーザー削除モード | 一般ユーザーが設定を削除できる方法を選択する（後述） |
@@ -173,11 +199,23 @@ VPS 設定・WireGuard パラメーターを変更できます。変更は次回
 
 ### WireGuard 制御
 
-**「WireGuard 停止 & iptables クリア」ボタン**で、WireGuard インターフェースを停止し、設定されたすべての iptables ルール（DNAT / FORWARD / MASQUERADE）を削除できます。使用をやめる場合や、iptables ルールが残留している場合に使用してください。
+#### 「IPv6 対応で全ポートを再適用」ボタン
+
+既存の全ポートに IPv6 ルール（ip6tables）を追加し、サーバー設定を更新します。新しく生成する設定に IPv6 アドレスを含めたい場合に使用します。
+
+実行前に VPS 側で以下を確認してください：
+- IPv6 フォワーディングが有効：`sudo sysctl net.ipv6.conf.all.forwarding`（1 なら OK）
+- ip6table_nat モジュールがロード：`sudo modprobe ip6table_nat`
+
+#### 「WireGuard 停止 & iptables クリア」ボタン
+
+WireGuard インターフェースを停止し、設定されたすべての iptables・ip6tables ルール（DNAT / FORWARD / MASQUERADE）を削除できます。使用をやめる場合や、iptables ルールが残留している場合に使用してください。
 
 ### 発行済みポート一覧
 
-発行されたポートの一覧と削除ができます。ポートを削除すると、自動適用が有効な場合は WireGuard 設定が即座に更新されます。管理者はモードにかかわらず常に削除できます。
+発行されたポートの一覧と削除ができます。各ポートの「設定を表示」ボタンで、IPv6 対応済みのクライアント設定を確認・ダウンロードできます。
+
+ポートを削除すると、自動適用が有効な場合は WireGuard 設定が即座に更新されます。管理者はモードにかかわらず常に削除できます。
 
 ### アクティビティログ
 
@@ -231,3 +269,42 @@ VPS 設定・WireGuard パラメーターを変更できます。変更は次回
 ## エンドユーザー向けガイド
 
 利用者への案内は `docs/利用ガイド.md` を GitHub Wiki にコピーして使用してください。
+
+---
+
+## 更新履歴
+
+### v1.1.0 (2026-05-29) — IPv6 対応
+
+**新機能**
+- **IPv6 サポート**: IPv4・IPv6 の両方のポート転送に対応
+  - WireGuard に IPv6 アドレス（ULA: `fd00::/64` など）を割り当て可能
+  - iptables と ip6tables を並行実装し、IPv4・IPv6 トラフィックを同時処理
+  - 既存の IPv4 ルールには影響なし
+
+- **管理画面の拡張**:
+  - IPv6 サブネット設定フィールド追加
+  - 「IPv6 対応で全ポートを再適用」ボタン（既存ポートを一括 IPv6 対応化）
+  - ポート一覧に「設定を表示」ボタン（クライアント設定をモーダルで確認）
+  - 事前確認コマンドを折りたたみで表示
+
+- **セットアップ自動化**:
+  - セットアップコマンドに IPv6 フォワーディング・ip6table_nat モジュール設定を追加
+
+**修正**
+- admin.php の JSON レスポンス生成を PHP ブロックの最初に移動（HTML 出力前に JSON を返すよう修正）
+- sudo 権限設定に ip6tables 関連コマンドを追加
+
+**詳細**
+- [IPv6 実装コミット](https://github.com/bee7813993/wireguard-portal/commit/8cab606)
+- [管理画面 UI 追加](https://github.com/bee7813993/wireguard-portal/commit/4142bf5)
+- [セットアップ情報追加](https://github.com/bee7813993/wireguard-portal/commit/db6cc1a)
+
+---
+
+### v1.0.0 (初版)
+
+- WireGuard ポート転送ポータル（IPv4 のみ）
+- 管理画面・ユーザーポータル
+- iptables DNAT / FORWARD / MASQUERADE 自動化
+- SQLite ベースの設定管理

--- a/admin.php
+++ b/admin.php
@@ -100,7 +100,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['action'] ?? '') === 'delet
 
 // ---- 設定保存 --------------------------------------------
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && !isset($_POST['action'])) {
-    $fields = ['vps_ip','wg_port','nic','subnet','wg_interface'];
+    $fields = ['vps_ip','wg_port','nic','subnet','subnet_ipv6','wg_interface'];
     foreach ($fields as $f) {
         if (isset($_POST[$f])) set_setting($f, trim($_POST[$f]));
     }
@@ -126,6 +126,7 @@ $cfg = [
     'wg_port'      => get_setting('wg_port'),
     'nic'          => get_setting('nic'),
     'subnet'       => get_setting('subnet'),
+    'subnet_ipv6'  => get_setting('subnet_ipv6'),
     'wg_interface' => get_setting('wg_interface') ?: 'wg0',
     'auto_apply'   => get_setting('auto_apply'),
     'delete_mode'  => get_setting('delete_mode') ?: 'none',
@@ -234,6 +235,11 @@ tr:hover td{background:#fafbfc}
           <label>WireGuard サブネット (先頭3オクテット)</label>
           <div class="desc">例: 10.0.0 → サーバー 10.0.0.1, クライアントは 10.0.0.2〜</div>
           <input type="text" name="subnet" value="<?= htmlspecialchars($cfg['subnet']) ?>" placeholder="10.0.0">
+        </div>
+        <div class="field">
+          <label>WireGuard IPv6 サブネット</label>
+          <div class="desc">例: fd00:: → サーバー fd00::1, クライアントは fd00::2〜 (ULA推奨)</div>
+          <input type="text" name="subnet_ipv6" value="<?= htmlspecialchars($cfg['subnet_ipv6']) ?>" placeholder="fd00::">
         </div>
         <div class="field">
           <label>WireGuard インターフェース名</label>

--- a/admin.php
+++ b/admin.php
@@ -339,6 +339,22 @@ tr:hover td{background:#fafbfc}
           既存の全ポートを含む WireGuard 設定を IPv6 ルール付きで書き直し、wg-quick で反映します。<br>
           適用後、各クライアントはポート一覧の「設定を表示」から新しい .conf を取得してください。
         </p>
+        <details style="margin-bottom:.9rem;font-size:12px;color:var(--muted)">
+          <summary style="cursor:pointer;font-family:var(--mono);color:var(--accent2)">事前確認: VPS で必要な設定</summary>
+          <div style="margin-top:.6rem;background:#f8fafc;border:1px solid var(--border);border-radius:7px;padding:10px 14px;line-height:2">
+            <code style="display:block;font-family:var(--mono);font-size:11px;white-space:pre"># IPv6 フォワーディング確認 (1 なら OK)
+sysctl net.ipv6.conf.all.forwarding
+# → 0 の場合:
+sudo sysctl -w net.ipv6.conf.all.forwarding=1
+echo 'net.ipv6.conf.all.forwarding=1' | sudo tee -a /etc/sysctl.conf
+
+# ip6table_nat モジュール確認
+lsmod | grep ip6table_nat
+# → 何も出ない場合:
+sudo modprobe ip6table_nat
+echo 'ip6table_nat' | sudo tee -a /etc/modules</code>
+          </div>
+        </details>
         <form method="post" onsubmit="return confirm('WireGuard設定をIPv6対応で再適用します。よろしいですか？')">
           <input type="hidden" name="action" value="apply_ipv6">
           <button type="submit" class="apply-btn">IPv6 対応で全ポートを再適用</button>

--- a/admin.php
+++ b/admin.php
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 <?php
 // =========================================================
 //  admin.php  – 管理画面: 内部パラメーター設定
@@ -18,7 +17,7 @@ if (isset($_GET['logout'])) {
     exit;
 }
 
-// ---- ログイン処理 ----------------------------------------
+// ---- ログイン認証必須 ----------------------------------------
 if (!isset($_SESSION[ADMIN_SESSION_KEY])) {
     if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['password'])) {
         $stored = get_setting('admin_pass');
@@ -30,6 +29,7 @@ if (!isset($_SESSION[ADMIN_SESSION_KEY])) {
         $error = 'パスワードが正しくありません。';
     }
     ?>
+<!DOCTYPE html>
 <html lang="ja">
 <head>
 <meta charset="UTF-8">

--- a/admin.php
+++ b/admin.php
@@ -68,6 +68,34 @@ button:hover{opacity:.9}
 </html>
     <?php exit; }
 
+// ---- クライアント設定を JSON で返す (Ajax) ---------------
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['action'] ?? '') === 'get_client_conf') {
+    header('Content-Type: application/json; charset=utf-8');
+    $port = (int)($_POST['port'] ?? 0);
+    if ($port < 1024 || $port > 65535) {
+        echo json_encode(['error' => '不正なポート番号です。']);
+        exit;
+    }
+    $result = WgManager::rebuild_client_conf($port);
+    if ($result === null) {
+        echo json_encode(['error' => "ポート {$port} は登録されていません。"]);
+        exit;
+    }
+    echo json_encode(['ok' => true, 'data' => $result]);
+    exit;
+}
+
+// ---- WireGuard 設定を IPv6 対応で再適用 ------------------
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['action'] ?? '') === 'apply_ipv6') {
+    $res = WgManager::apply_server_config();
+    if ($res['success']) {
+        $success = '全ポートを IPv6 対応で再適用しました。クライアントの設定ファイルも更新してください。';
+    } else {
+        $error = 'サーバー設定の適用に失敗しました: ' . $res['output'];
+    }
+    write_log('INFO', '管理者が IPv6 対応で設定を再適用しました');
+}
+
 // ---- WireGuard停止 & iptablesクリア ---------------------
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['action'] ?? '') === 'teardown') {
     $res = WgManager::teardown();
@@ -191,6 +219,22 @@ tr:hover td{background:#fafbfc}
 .del-btn:hover{background:#fef2f2;border-color:var(--err)}
 .stop-btn{padding:10px 24px;background:transparent;border:1.5px solid #fca5a5;border-radius:9px;color:var(--err);font-family:var(--mono);font-size:13px;font-weight:500;cursor:pointer;transition:background .12s,border-color .12s}
 .stop-btn:hover{background:#fef2f2;border-color:var(--err)}
+.apply-btn{padding:10px 24px;background:var(--accent);color:#fff;font-family:var(--mono);font-size:13px;font-weight:500;border:none;border-radius:9px;cursor:pointer;transition:opacity .15s;box-shadow:0 2px 8px rgba(5,150,105,.25)}
+.apply-btn:hover{opacity:.9}
+.conf-btn{padding:4px 13px;background:transparent;border:1px solid #a5b4fc;border-radius:5px;color:#4338ca;font-family:var(--mono);font-size:11px;cursor:pointer;transition:background .12s,border-color .12s;white-space:nowrap}
+.conf-btn:hover{background:#ede9fe;border-color:#6366f1}
+.conf-modal{display:none;position:fixed;inset:0;background:rgba(0,0,0,.45);z-index:1000;place-items:center}
+.conf-modal.open{display:grid}
+.conf-modal-box{background:#fff;border-radius:14px;padding:1.75rem;width:min(640px,92vw);box-shadow:0 8px 40px rgba(0,0,0,.18);max-height:90vh;overflow-y:auto}
+.conf-modal-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:1.1rem}
+.conf-modal-title{font-family:var(--mono);font-size:13px;font-weight:500;color:var(--text)}
+.conf-modal-close{background:none;border:none;font-size:20px;color:var(--muted);cursor:pointer;line-height:1;padding:2px 6px;border-radius:5px;transition:color .12s}
+.conf-modal-close:hover{color:var(--text)}
+.conf-code{background:#f8fafc;border:1px solid var(--border);border-radius:9px;padding:14px 16px;font-family:var(--mono);font-size:12px;line-height:1.75;color:var(--text);white-space:pre;overflow-x:auto;margin-bottom:1rem}
+.conf-dl-btn{display:inline-block;padding:8px 18px;background:var(--accent2);color:#fff;font-family:var(--mono);font-size:12px;border:none;border-radius:7px;cursor:pointer;transition:opacity .15s}
+.conf-dl-btn:hover{opacity:.9}
+.conf-copy-btn{display:inline-block;padding:8px 18px;background:transparent;color:var(--accent);border:1px solid var(--accent);font-family:var(--mono);font-size:12px;border-radius:7px;cursor:pointer;transition:background .12s;margin-left:8px}
+.conf-copy-btn:hover{background:#f0fdf4}
 .log-area{max-height:360px;overflow-y:auto;padding:1rem;background:#f8fafc;font-family:var(--mono);font-size:11px;line-height:1.75;border-radius:0 0 14px 14px}
 .log-line{color:var(--muted);white-space:pre-wrap;word-break:break-all}
 .log-line.info{color:var(--text)}
@@ -288,15 +332,29 @@ tr:hover td{background:#fafbfc}
   <!-- WireGuard制御 -->
   <div>
     <div class="section-title">WireGuard 制御</div>
-    <div class="card">
-      <p style="font-size:13px;color:var(--muted);margin-bottom:1.25rem;line-height:1.7">
-        WireGuardインターフェースを停止し、設定された全ての iptables ルール（DNAT / FORWARD / MASQUERADE）を削除します。<br>
-        使用をやめる場合や、iptables のルールが残留している場合はこのボタンを押してください。
-      </p>
-      <form method="post" onsubmit="return confirm('WireGuardを停止し、iptablesルールをすべて削除します。よろしいですか？')">
-        <input type="hidden" name="action" value="teardown">
-        <button type="submit" class="stop-btn">WireGuard 停止 &amp; iptables クリア</button>
-      </form>
+    <div class="card" style="display:flex;flex-direction:column;gap:1.25rem">
+      <div>
+        <p style="font-size:13px;color:var(--text);font-weight:500;margin-bottom:.4rem">IPv6 対応で再適用</p>
+        <p style="font-size:13px;color:var(--muted);margin-bottom:.9rem;line-height:1.7">
+          既存の全ポートを含む WireGuard 設定を IPv6 ルール付きで書き直し、wg-quick で反映します。<br>
+          適用後、各クライアントはポート一覧の「設定を表示」から新しい .conf を取得してください。
+        </p>
+        <form method="post" onsubmit="return confirm('WireGuard設定をIPv6対応で再適用します。よろしいですか？')">
+          <input type="hidden" name="action" value="apply_ipv6">
+          <button type="submit" class="apply-btn">IPv6 対応で全ポートを再適用</button>
+        </form>
+      </div>
+      <div style="border-top:1px solid var(--border);padding-top:1.25rem">
+        <p style="font-size:13px;color:var(--text);font-weight:500;margin-bottom:.4rem">WireGuard 停止 &amp; iptables クリア</p>
+        <p style="font-size:13px;color:var(--muted);margin-bottom:.9rem;line-height:1.7">
+          WireGuardインターフェースを停止し、設定された全ての iptables ルール（DNAT / FORWARD / MASQUERADE）を削除します。<br>
+          使用をやめる場合や、iptables のルールが残留している場合はこのボタンを押してください。
+        </p>
+        <form method="post" onsubmit="return confirm('WireGuardを停止し、iptablesルールをすべて削除します。よろしいですか？')">
+          <input type="hidden" name="action" value="teardown">
+          <button type="submit" class="stop-btn">WireGuard 停止 &amp; iptables クリア</button>
+        </form>
+      </div>
     </div>
   </div>
 
@@ -313,7 +371,7 @@ tr:hover td{background:#fafbfc}
             <th>ポート</th>
             <th>クライアント公開鍵</th>
             <th>最終更新</th>
-            <th style="width:72px"></th>
+            <th style="width:130px"></th>
           </tr>
         </thead>
         <tbody>
@@ -322,7 +380,8 @@ tr:hover td{background:#fafbfc}
             <td><span class="port-badge"><?= (int)$r['port'] ?></span></td>
             <td style="color:var(--muted)"><?= htmlspecialchars(substr($r['client_pub'],0,24)) ?>…</td>
             <td style="color:var(--muted)"><?= htmlspecialchars($r['updated_at']) ?></td>
-            <td>
+            <td style="display:flex;gap:6px;align-items:center">
+              <button class="conf-btn" onclick="showClientConf(<?= (int)$r['port'] ?>)">設定を表示</button>
               <form method="post" onsubmit="return confirm('ポート <?= (int)$r['port'] ?> を削除しますか？\nこの操作は元に戻せません。')">
                 <input type="hidden" name="action" value="delete_port">
                 <input type="hidden" name="del_port" value="<?= (int)$r['port'] ?>">
@@ -359,5 +418,76 @@ tr:hover td{background:#fafbfc}
   </div>
 
 </main>
+
+<!-- クライアント設定モーダル -->
+<div class="conf-modal" id="conf-modal" onclick="if(event.target===this)closeModal()">
+  <div class="conf-modal-box">
+    <div class="conf-modal-header">
+      <span class="conf-modal-title" id="conf-modal-title">クライアント設定</span>
+      <button class="conf-modal-close" onclick="closeModal()">×</button>
+    </div>
+    <p style="font-size:12px;color:var(--muted);margin-bottom:.9rem;line-height:1.6">
+      このファイルを WireGuard クライアントにインポートしてください。<br>
+      既存の設定を <strong>上書き（インポートし直し）</strong> することで IPv6 に対応します。
+    </p>
+    <div class="conf-code" id="conf-modal-code"></div>
+    <button class="conf-dl-btn" id="conf-dl-btn">↓ .conf をダウンロード</button>
+    <button class="conf-copy-btn" id="conf-copy-btn" onclick="copyConf()">コピー</button>
+  </div>
+</div>
+
+<script>
+let _confText = '';
+let _confPort = 0;
+
+async function showClientConf(port) {
+  const modal = document.getElementById('conf-modal');
+  const codeEl = document.getElementById('conf-modal-code');
+  const titleEl = document.getElementById('conf-modal-title');
+  titleEl.textContent = `クライアント設定 — ポート ${port}`;
+  codeEl.textContent = '読み込み中…';
+  modal.classList.add('open');
+
+  const fd = new FormData();
+  fd.append('action', 'get_client_conf');
+  fd.append('port', port);
+  try {
+    const res  = await fetch('admin.php', { method: 'POST', body: fd });
+    const json = await res.json();
+    if (json.ok) {
+      _confText = json.data.client_conf;
+      _confPort = json.data.port;
+      codeEl.textContent = _confText;
+      document.getElementById('conf-dl-btn').onclick = () => downloadConf();
+    } else {
+      codeEl.textContent = 'エラー: ' + (json.error || '不明なエラー');
+    }
+  } catch (e) {
+    codeEl.textContent = '通信エラー: ' + e.message;
+  }
+}
+
+function closeModal() {
+  document.getElementById('conf-modal').classList.remove('open');
+}
+
+function downloadConf() {
+  const blob = new Blob([_confText], { type: 'text/plain' });
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = `wg-client_${_confPort}.conf`;
+  a.click();
+}
+
+function copyConf() {
+  navigator.clipboard.writeText(_confText).then(() => {
+    const btn = document.getElementById('conf-copy-btn');
+    btn.textContent = 'コピーしました！';
+    setTimeout(() => btn.textContent = 'コピー', 1500);
+  });
+}
+
+document.addEventListener('keydown', e => { if (e.key === 'Escape') closeModal(); });
+</script>
 </body>
 </html>

--- a/config.php
+++ b/config.php
@@ -51,6 +51,7 @@ function get_db(): PDO {
         'wg_port'      => '51820',
         'nic'          => 'eth0',
         'subnet'       => '10.0.0',
+        'subnet_ipv6'  => 'fd00::',
         'wg_interface' => 'wg0',
         'auto_apply'   => '0',
         'delete_mode'  => 'none',

--- a/wg_manager.php
+++ b/wg_manager.php
@@ -336,6 +336,30 @@ class WgManager {
         return ['success' => $success, 'output' => trim($output)];
     }
 
+    // ---- 既存ポートの設定を鍵を変えずに再生成 ------------
+    public static function rebuild_client_conf(int $port): ?array {
+        $db   = get_db();
+        $stmt = $db->prepare("SELECT id, client_priv, client_pub FROM wg_configs WHERE port = ?");
+        $stmt->execute([$port]);
+        $row = $stmt->fetch();
+        if (!$row) return null;
+
+        $server_kp   = get_or_create_server_keypair();
+        $subnet      = get_setting('subnet');
+        $server_ip   = $subnet . '.1';
+        $octet       = (((int)$row['id'] - 1) % 253) + 2;
+        $client_ip   = $subnet . '.' . $octet;
+
+        $client_conf = self::build_client_conf(
+            $row['client_priv'], $server_kp['pub'], $client_ip, $server_ip
+        );
+        return [
+            'port'        => $port,
+            'client_ip'   => $client_ip,
+            'client_conf' => $client_conf,
+        ];
+    }
+
     // ---- メイン: ポートに対してキーペアを発行/再発行 ----
     public static function issue(int $port): array {
         $db          = get_db();

--- a/wg_manager.php
+++ b/wg_manager.php
@@ -23,16 +23,23 @@ class WgManager {
     ): string {
         $vps_ip  = get_setting('vps_ip');
         $wg_port = get_setting('wg_port');
+        $subnet_ipv6 = get_setting('subnet_ipv6');
+
+        // IPv6 アドレス生成
+        $ipv4_parts = explode('.', $client_ip);
+        $ipv4_last = (int)end($ipv4_parts);
+        $client_ip6 = $subnet_ipv6 . dechex($ipv4_last);
+        $server_ip6 = $subnet_ipv6 . '1';
 
         return "[Interface]\n"
              . "PrivateKey = {$client_priv}\n"
-             . "Address = {$client_ip}/24\n"
+             . "Address = {$client_ip}/24, {$client_ip6}/64\n"
              . "DNS = 1.1.1.1\n"
              . "\n"
              . "[Peer]\n"
              . "PublicKey = {$server_pub}\n"
              . "Endpoint = {$vps_ip}:{$wg_port}\n"
-             . "AllowedIPs = {$server_ip}/32\n"
+             . "AllowedIPs = {$server_ip}/32, {$server_ip6}/128\n"
              . "PersistentKeepalive = 25\n";
     }
 
@@ -40,7 +47,9 @@ class WgManager {
     public static function build_full_server_conf(): string {
         $server_kp = get_or_create_server_keypair();
         $subnet    = get_setting('subnet');
+        $subnet_ipv6 = get_setting('subnet_ipv6');
         $server_ip = $subnet . '.1';
+        $server_ip6 = $subnet_ipv6 . '1';
         $wg_port   = get_setting('wg_port');
         $nic       = get_setting('nic');
         $iface     = self::sanitize_interface(get_setting('wg_interface') ?: 'wg0');
@@ -48,28 +57,43 @@ class WgManager {
         $db   = get_db();
         $rows = $db->query("SELECT id, port, client_pub FROM wg_configs ORDER BY id ASC")->fetchAll();
 
-        // MASQUERADE は一度だけ
-        $up_lines   = ["iptables -t nat -A POSTROUTING -o {$iface} -j MASQUERADE"];
-        $down_lines = ["iptables -t nat -D POSTROUTING -o {$iface} -j MASQUERADE"];
+        // MASQUERADE は一度だけ (IPv4 & IPv6)
+        $up_lines   = [
+            "iptables -t nat -A POSTROUTING -o {$iface} -j MASQUERADE",
+            "ip6tables -t nat -A POSTROUTING -o {$iface} -j MASQUERADE",
+        ];
+        $down_lines = [
+            "iptables -t nat -D POSTROUTING -o {$iface} -j MASQUERADE",
+            "ip6tables -t nat -D POSTROUTING -o {$iface} -j MASQUERADE",
+        ];
 
         $peer_blocks = '';
         foreach ($rows as $row) {
-            $octet     = (($row['id'] - 1) % 253) + 2;
-            $client_ip = $subnet . '.' . $octet;
-            $port      = (int)$row['port'];
+            $octet      = (($row['id'] - 1) % 253) + 2;
+            $client_ip  = $subnet . '.' . $octet;
+            $client_ip6 = $subnet_ipv6 . dechex($octet);
+            $port       = (int)$row['port'];
 
+            // IPv4 ルール
             $up_lines[]   = "iptables -t nat -A PREROUTING -i {$nic} -p tcp --dport {$port} -j DNAT --to-destination {$client_ip}:80";
             $up_lines[]   = "iptables -A FORWARD -p tcp -d {$client_ip} --dport 80 -j ACCEPT";
             $down_lines[] = "iptables -t nat -D PREROUTING -i {$nic} -p tcp --dport {$port} -j DNAT --to-destination {$client_ip}:80";
             $down_lines[] = "iptables -D FORWARD -p tcp -d {$client_ip} --dport 80 -j ACCEPT";
 
+            // IPv6 ルール
+            $up_lines[]   = "ip6tables -t nat -A PREROUTING -i {$nic} -p tcp --dport {$port} -j DNAT --to-destination [{$client_ip6}]:80";
+            $up_lines[]   = "ip6tables -A FORWARD -p tcp -d {$client_ip6} --dport 80 -j ACCEPT";
+            $down_lines[] = "ip6tables -t nat -D PREROUTING -i {$nic} -p tcp --dport {$port} -j DNAT --to-destination [{$client_ip6}]:80";
+            $down_lines[] = "ip6tables -D FORWARD -p tcp -d {$client_ip6} --dport 80 -j ACCEPT";
+
+            // WireGuardは両方のアドレスを許可
             $peer_blocks .= "\n[Peer]\n"
                          .  "PublicKey = {$row['client_pub']}\n"
-                         .  "AllowedIPs = {$client_ip}/32\n";
+                         .  "AllowedIPs = {$client_ip}/32, {$client_ip6}/128\n";
         }
 
         $conf = "[Interface]\n"
-              . "Address = {$server_ip}/24\n"
+              . "Address = {$server_ip}/24, {$server_ip6}/64\n"
               . "ListenPort = {$wg_port}\n"
               . "PrivateKey = {$server_kp['priv']}\n"
               . "\n";
@@ -91,25 +115,40 @@ class WgManager {
         $wg_port = get_setting('wg_port');
         $nic     = get_setting('nic');
         $iface   = get_setting('wg_interface') ?: 'wg0';
+        $subnet_ipv6 = get_setting('subnet_ipv6');
+
+        // IPv6 アドレス生成 (IPv4 の最後の八進数から十六進数に変換)
+        $ipv4_parts = explode('.', $client_ip);
+        $ipv4_last = (int)end($ipv4_parts);
+        $client_ip6 = $subnet_ipv6 . dechex($ipv4_last);
+        $server_ip6 = $subnet_ipv6 . '1';
 
         $post_up   = self::iptables_rules($nic, $iface, $ext_port, $client_ip, '-A', '-A');
+        $post_up6  = self::ip6tables_rules($nic, $iface, $ext_port, $client_ip6, '-A', '-A');
         $post_down = self::iptables_rules($nic, $iface, $ext_port, $client_ip, '-D', '-D');
+        $post_down6 = self::ip6tables_rules($nic, $iface, $ext_port, $client_ip6, '-D', '-D');
 
         return "[Interface]\n"
-             . "Address = {$server_ip}/24\n"
+             . "Address = {$server_ip}/24, {$server_ip6}/64\n"
              . "ListenPort = {$wg_port}\n"
              . "PrivateKey = {$server_priv}\n"
              . "\n"
              . "PostUp   = {$post_up[0]}\n"
              . "PostUp   = {$post_up[1]}\n"
              . "PostUp   = {$post_up[2]}\n"
+             . "PostUp   = {$post_up6[0]}\n"
+             . "PostUp   = {$post_up6[1]}\n"
+             . "PostUp   = {$post_up6[2]}\n"
              . "PostDown = {$post_down[0]}\n"
              . "PostDown = {$post_down[1]}\n"
              . "PostDown = {$post_down[2]}\n"
+             . "PostDown = {$post_down6[0]}\n"
+             . "PostDown = {$post_down6[1]}\n"
+             . "PostDown = {$post_down6[2]}\n"
              . "\n"
              . "[Peer]\n"
              . "PublicKey = {$client_pub}\n"
-             . "AllowedIPs = {$client_ip}/32\n";
+             . "AllowedIPs = {$client_ip}/32, {$client_ip6}/128\n";
     }
 
     private static function iptables_rules(
@@ -127,6 +166,21 @@ class WgManager {
         ];
     }
 
+    private static function ip6tables_rules(
+        string $nic,
+        string $iface,
+        int    $ext_port,
+        string $client_ip6,
+        string $nat_flag,
+        string $fwd_flag
+    ): array {
+        return [
+            "ip6tables -t nat {$nat_flag} PREROUTING -i {$nic} -p tcp --dport {$ext_port} -j DNAT --to-destination [{$client_ip6}]:80",
+            "ip6tables {$fwd_flag} FORWARD -p tcp -d {$client_ip6} --dport 80 -j ACCEPT",
+            "ip6tables -t nat {$nat_flag} POSTROUTING -o {$iface} -j MASQUERADE",
+        ];
+    }
+
     // ---- セットアップコマンド生成 -------------------------
     public static function build_setup_commands(int $ext_port): string {
         $wg_port = get_setting('wg_port');
@@ -134,8 +188,9 @@ class WgManager {
 
         return "# 1. WireGuardインストール\n"
              . "sudo apt update && sudo apt install wireguard -y\n\n"
-             . "# 2. IPフォワーディングを有効化\n"
+             . "# 2. IP フォワーディングを有効化 (IPv4 & IPv6)\n"
              . "echo \"net.ipv4.ip_forward=1\" | sudo tee -a /etc/sysctl.conf\n"
+             . "echo \"net.ipv6.conf.all.forwarding=1\" | sudo tee -a /etc/sysctl.conf\n"
              . "sudo sysctl -p\n\n"
              . "# 3. {$iface}.conf を配置 (上の内容を保存)\n"
              . "sudo nano /etc/wireguard/{$iface}.conf\n\n"
@@ -173,7 +228,9 @@ class WgManager {
     // ---- 残留iptablesルールの全削除 ----------------------
     private static function flush_stale_iptables(string $iface): void {
         $subnet = get_setting('subnet');
+        $subnet_ipv6 = get_setting('subnet_ipv6');
 
+        // IPv4 処理
         // nat PREROUTING: サブネット宛のDNATルールを削除
         exec('sudo iptables -t nat -S PREROUTING 2>/dev/null', $nat_rules);
         foreach ($nat_rules as $rule) {
@@ -198,6 +255,34 @@ class WgManager {
             if (str_contains($rule, $iface) && str_contains($rule, 'MASQUERADE')) {
                 $del = str_replace('-A POSTROUTING', '-D POSTROUTING', $rule);
                 exec('sudo iptables -t nat ' . $del . ' 2>/dev/null');
+            }
+        }
+
+        // IPv6 処理
+        // nat PREROUTING: IPv6 サブネット宛のDNATルールを削除
+        exec('sudo ip6tables -t nat -S PREROUTING 2>/dev/null', $nat_rules6);
+        foreach ($nat_rules6 as $rule) {
+            if (str_contains($rule, $subnet_ipv6)) {
+                $del = str_replace('-A PREROUTING', '-D PREROUTING', $rule);
+                exec('sudo ip6tables -t nat ' . $del . ' 2>/dev/null');
+            }
+        }
+
+        // filter FORWARD: IPv6 サブネット宛のFORWARDルールを削除
+        exec('sudo ip6tables -S FORWARD 2>/dev/null', $fwd_rules6);
+        foreach ($fwd_rules6 as $rule) {
+            if (str_contains($rule, $subnet_ipv6)) {
+                $del = str_replace('-A FORWARD', '-D FORWARD', $rule);
+                exec('sudo ip6tables ' . $del . ' 2>/dev/null');
+            }
+        }
+
+        // nat POSTROUTING: このインターフェースのMASQUERADEルール（IPv6）を削除
+        exec('sudo ip6tables -t nat -S POSTROUTING 2>/dev/null', $post_rules6);
+        foreach ($post_rules6 as $rule) {
+            if (str_contains($rule, $iface) && str_contains($rule, 'MASQUERADE')) {
+                $del = str_replace('-A POSTROUTING', '-D POSTROUTING', $rule);
+                exec('sudo ip6tables -t nat ' . $del . ' 2>/dev/null');
             }
         }
     }

--- a/wg_manager.php
+++ b/wg_manager.php
@@ -187,21 +187,25 @@ class WgManager {
         $iface   = get_setting('wg_interface') ?: 'wg0';
 
         return "# 1. WireGuardインストール\n"
-             . "sudo apt update && sudo apt install wireguard -y\n\n"
+             . "sudo apt update && sudo apt install wireguard iptables -y\n\n"
              . "# 2. IP フォワーディングを有効化 (IPv4 & IPv6)\n"
              . "echo \"net.ipv4.ip_forward=1\" | sudo tee -a /etc/sysctl.conf\n"
              . "echo \"net.ipv6.conf.all.forwarding=1\" | sudo tee -a /etc/sysctl.conf\n"
              . "sudo sysctl -p\n\n"
-             . "# 3. {$iface}.conf を配置 (上の内容を保存)\n"
+             . "# 3. ip6tables NAT モジュールを有効化 (IPv6 NAT に必要)\n"
+             . "sudo modprobe ip6table_nat\n"
+             . "echo 'ip6table_nat' | sudo tee -a /etc/modules\n\n"
+             . "# 4. {$iface}.conf を配置 (上の内容を保存)\n"
              . "sudo nano /etc/wireguard/{$iface}.conf\n\n"
-             . "# 4. 起動・自動起動\n"
+             . "# 5. 起動・自動起動\n"
              . "sudo wg-quick up {$iface}\n"
              . "sudo systemctl enable wg-quick@{$iface}\n\n"
-             . "# 5. ファイアウォール開放\n"
+             . "# 6. ファイアウォール開放\n"
              . "sudo ufw allow {$wg_port}/udp\n"
              . "sudo ufw allow {$ext_port}/tcp\n\n"
-             . "# 6. 状態確認\n"
-             . "sudo wg show\n";
+             . "# 7. 状態確認\n"
+             . "sudo wg show\n"
+             . "sudo ip6tables -t nat -L -n\n";
     }
 
     // ---- WireGuard停止 & iptables全削除 -----------------


### PR DESCRIPTION
## 概要

WireGuard Portal に IPv6 対応を追加しました。IPv4・IPv6 の両方のポート転送に対応するようになります。

## 新機能

### 1. IPv6 サポート (iptables + ip6tables 並行実装)
- WireGuard に IPv6 アドレス（ULA: `fd00::/64` など）を割り当て可能
- iptables と ip6tables を並行実装し、IPv4・IPv6 トラフィックを同時処理
- 既存の IPv4 ルールには影響なし、後方互換性を維持

### 2. 管理画面の拡張
- **IPv6 サブネット設定**: 管理画面に「WireGuard IPv6 サブネット」設定フィールドを追加
- **「IPv6 対応で全ポートを再適用」ボタン**: 既存ポート全体を IPv6 対応で一括更新
  - 実行前の確認コマンド（IPv6 フォワーディング・ip6table_nat モジュール確認）を折りたたみで表示
- **ポート一覧に「設定を表示」ボタン**: 既存ポートの IPv6 対応設定を確認・ダウンロード
  - モーダルでクライアント設定を表示
  - `.conf` ダウンロード / クリップボードコピー機能

### 3. クライアント設定の IPv6 対応
- `build_client_conf()`: IPv6 アドレスを Address と AllowedIPs に追加
- `rebuild_client_conf()`: 既存の鍵を使いながら IPv6 対応設定を再生成

### 4. セットアップ自動化
- セットアップコマンドに IPv6 フォワーディング・ip6table_nat モジュール設定を追加
- 確認コマンドに `ip6tables -t nat -L -n` を追加

## 実装の詳細

### ファイル修正

#### config.php
- デフォルト設定に `subnet_ipv6` 追加（デフォルト: `fd00::`）

#### wg_manager.php
- `build_full_server_conf()`: IPv6 ルール生成、Address に /64 を追加
- `build_server_conf_snippet()`: IPv6 対応
- `build_client_conf()`: IPv6 アドレスをクライアント設定に含める
- `ip6tables_rules()`: IPv6 専用ルール生成関数を追加
- `rebuild_client_conf()`: 既存ポートの設定を鍵を変えずに再生成
- `flush_stale_iptables()`: IPv6 ルール削除処理を統合
- `build_setup_commands()`: IPv6 フォワーディング・モジュール設定を追加

#### admin.php
- PHP ブロックをファイルの最初に移動（JSON 返答エラー修正）
- `get_client_conf` Ajax エンドポイント追加
- `apply_ipv6` アクション追加（全ポート IPv6 再適用）
- IPv6 サブネット設定フィールドを追加
- 「IPv6 対応で再適用」ボタンと「設定を表示」ボタンのUI追加
- モーダルと JavaScript で設定表示機能を実装

#### README.md
- 構成図を IPv4/IPv6 対応に更新
- 動作要件に ip6tables とIPv6フォワーディングを追加
- セットアップ手順に ip6table_nat モジュール設定を追加
- sudo 権限設定に ip6tables コマンドを追加
- 初期設定に IPv6 サブネット設定を説明
- 管理画面機能を詳細説明
- 更新履歴セクション (v1.1.0) を追加

## IPv6 アドレス生成ロジック

- IPv4 オクテット（2～254）→ 16進数変換 → IPv6 ホストアドレス
  - 例: id=1（octet=2） → `fd00::2`
  - 例: id=255（octet=254） → `fd00::fe`
- WireGuard の AllowedIPs に IPv4・IPv6 両方を記載

## セットアップに必要な追加手順

VPS で以下を実施してください：

```bash
# IPv6 フォワーディング有効化
echo "net.ipv6.conf.all.forwarding=1" | sudo tee -a /etc/sysctl.conf
sudo sysctl -p

# ip6table_nat モジュールロード
sudo modprobe ip6table_nat
echo "ip6table_nat" | sudo tee -a /etc/modules
```

## テスト項目

- [x] IPv4 ポート転送が既存通り動作
- [x] IPv6 ポート転送が動作
- [x] 既存ポートの IPv6 対応設定再生成
- [x] クライアント設定に IPv6 アドレスが含まれている
- [x] 管理画面の IPv6 設定が反映される
- [x] 折りたたみ表示が機能している

## 関連コミット

- 8cab606: IPv6対応: iptablesルールをip6tablesで並行実装
- 4142bf5: 管理画面: 既存ポートのIPv6対応ボタン追加
- b197d6b: fix: admin.phpのJSON返答エラー修正
- db6cc1a: IPv6有効化の事前確認手順を管理画面とセットアップコマンドに追加
- 5b6e7cb: docs: README.md を IPv6 対応版に更新

---
_Generated by [Claude Code](https://claude.ai/code/session_01VcZ6RiodJh7V4aW9SotkGP)_